### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/go-vcard/security/code-scanning/1](https://github.com/RumenDamyanov/go-vcard/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. This can be done at the workflow level (applies to all jobs) or at the job level (applies to a specific job). Since the workflow only checks out code, runs tests, and uploads coverage to Codecov (which uses its own token), the minimal permission required is `contents: read`. Add the following block after the workflow `name` and before the `on` block in `.github/workflows/ci.yml`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
